### PR TITLE
Potential fix for code scanning alert no. 154: Information exposure through a stack trace

### DIFF
--- a/istampit-web/app/api/stamp/route.ts
+++ b/istampit-web/app/api/stamp/route.ts
@@ -130,7 +130,7 @@ export async function GET(req: NextRequest){
   return new Response(copy, { status: 200, headers: { 'Content-Type':'application/octet-stream', 'Content-Disposition':`attachment; filename="${hash}.ots"`, 'Cache-Control':'no-store' } });
   } catch(e:any){
     console.error('stamp_failed', e);
-    return json({ error: 'stamp_failed', message: 'An error occurred while stamping.' }, 500);
+    return json({ error: 'stamp_failed', message: 'Failed to retrieve stamp.' }, 500);
   } finally { await fs.rm(tmp).catch(()=>{}); }
 }
 


### PR DESCRIPTION
Potential fix for [https://github.com/SinAi-Inc/iStampit.io/security/code-scanning/154](https://github.com/SinAi-Inc/iStampit.io/security/code-scanning/154)

To fix the problem, we should ensure that error responses sent to the client do not include internal error messages or details that could reveal sensitive information. Instead, we should send a generic error message (e.g., "An error occurred" or "stamp_failed") and log the actual error message and stack trace on the server for debugging purposes.

Specifically:
- In the `POST` and `GET` handlers, replace the error responses that include `e?.message || String(e)` with a generic message.
- Add server-side logging for the error details (using `console.error`).
- The `json` function does not need to be changed, as it is just a wrapper for sending JSON responses.
- All changes are within `istampit-web/app/api/stamp/route.ts`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
